### PR TITLE
Inherrit CFLAGS in kaem makefile.

### DIFF
--- a/Kaem/makefile
+++ b/Kaem/makefile
@@ -21,7 +21,7 @@ VPATH = ../bin:test/results
 all: kaem
 
 CC=gcc
-CFLAGS=-D_GNU_SOURCE -std=c99 -ggdb
+CFLAGS:=$(CFLAGS) -D_GNU_SOURCE -std=c99 -ggdb
 
 kaem: kaem.c
 	$(CC) $(CFLAGS) kaem.c variable.c ../functions/file_print.c ../functions/match.c ../functions/in_set.c ../functions/string.c ../functions/require.c ../functions/numerate_number.c -o ../bin/kaem


### PR DESCRIPTION
This fixes reproducibility issues on Debian, as it allows
-ffile-prefix-map or -fdebug-prefix-map to strip out the build path,
which otherwise gets embedded in the binaries.