### PR TITLE
[hex2] Add aligned addressing for AArch64

### DIFF
--- a/hex2_linker.c
+++ b/hex2_linker.c
@@ -287,6 +287,11 @@ int Architectural_displacement(int target, int base)
 		 */
 		return ((target - base) - 8 + (3 & base));
 	}
+	else if(ALIGNED && (AARM64 == Architecture))
+	{
+			ALIGNED = FALSE;
+			return (target - (~3 & base)) >> 2;
+	}
 	else if (AARM64 == Architecture)
 	{
 		return ((target - base) - 8 + (3 & base));


### PR DESCRIPTION
- Add ^~label syntax for 3-byte relative, aligned offsets for AArch64
  for direct branch (and link) instructions.

- Unfortunately, AArch64 branch offsets are slightly bigger than 3
  bytes, so the mnemonic needs to differentiate between forward and
  backward (negative) offsets. This is straightforward (if tedious) for
  the handwritten tools in mescc-tools-seed, but M2-Planet would need some
  wider changes to make use of these.