### PR TITLE
Add RISC-V support to M1 and hex_linker

### DIFF
--- a/M1-macro.c
+++ b/M1-macro.c
@@ -45,6 +45,8 @@
 #define AARM64 80
 // CONSTANT PPC64LE 90
 #define PPC64LE 90
+#define RISCV32 243
+#define RISCV64 ((1<<16) | 243) /* set bit 16 to distinguish it while keeping the same ELF machine */
 
 /* How do you want that output? */
 // CONSTANT HEX 16
@@ -680,7 +682,7 @@ void eval_immediates(struct blob* p)
 		else if('<' == i->Text[0]) continue;
 		else if(NULL == i->Expression)
 		{
-			if((X86 == Architecture) || (AMD64 == Architecture) || (ARMV7L == Architecture) || (AARM64 == Architecture) || (PPC64LE == Architecture))
+			if((X86 == Architecture) || (AMD64 == Architecture) || (ARMV7L == Architecture) || (AARM64 == Architecture) || (PPC64LE == Architecture) || (RISCV32 == Architecture) || (RISCV64 == Architecture))
 			{
 				if(in_set(i->Text[0], "%~@!"))
 				{
@@ -791,6 +793,8 @@ int main(int argc, char **argv)
 			else if(match("armv7l", arch)) Architecture = ARMV7L;
 			else if(match("aarch64", arch)) Architecture = AARM64;
 			else if(match("ppc64le", arch)) Architecture = PPC64LE;
+			else if(match("riscv32", arch)) Architecture = RISCV32;
+			else if(match("riscv64", arch)) Architecture = RISCV64;
 			else
 			{
 				fputs("Unknown architecture: ", stderr);
@@ -810,7 +814,7 @@ int main(int argc, char **argv)
 			fputs("Usage: ", stderr);
 			fputs(argv[0], stderr);
 			fputs(" --file FILENAME1 {-f FILENAME2} (--big-endian|--little-endian) ", stderr);
-			fputs("[--architecture name]\nArchitectures: knight-native, knight-posix, x86, amd64 and armv7\n", stderr);
+			fputs("[--architecture name]\nArchitectures: knight-native, knight-posix, x86, amd64, armv7, riscv32 and riscv64\n", stderr);
 			fputs("To leverage octal or binary output: --octal, --binary\n", stderr);
 			exit(EXIT_SUCCESS);
 		}

--- a/hex2_linker.c
+++ b/hex2_linker.c
@@ -34,6 +34,8 @@
 #define ARMV7L 40
 #define AARM64 80
 #define PPC64LE 90
+#define RISCV32 243
+#define RISCV64 ((1<<16) | 243) /* set bit 16 to distinguish it while keeping the same ELF machine */
 
 #define HEX 16
 #define OCTAL 8
@@ -303,6 +305,7 @@ int Architectural_displacement(int target, int base)
 		/* DO *NOT* set link register with branch */
 		return (target - (base & 0xFFFFFFFC));
 	}
+	else if(RISCV32 == Architecture || RISCV64 == Architecture) return (target - base);
 
 	fputs("Unknown Architecture, aborting before harm is done\n", stderr);
 	exit(EXIT_FAILURE);
@@ -472,7 +475,7 @@ void process_byte(char c, FILE* source_file, int write)
 
 void pad_to_align(int write)
 {
-	if((ARMV7L == Architecture) || (AARM64 == Architecture))
+	if((ARMV7L == Architecture) || (AARM64 == Architecture) || (RISCV32 == Architecture) || (RISCV64 == Architecture))
 	{
 		if(1 == (ip & 0x1))
 		{
@@ -628,11 +631,13 @@ int main(int argc, char **argv)
 			else if(match("armv7l", arch)) Architecture = ARMV7L;
 			else if(match("aarch64", arch)) Architecture = AARM64;
 			else if(match("ppc64le", arch)) Architecture = PPC64LE;
+			else if(match("riscv32", arch)) Architecture = RISCV32;
+			else if(match("riscv64", arch)) Architecture = RISCV64;
 			else
 			{
 				fputs("Unknown architecture: ", stderr);
 				fputs(arch, stderr);
-				fputs(" know values are: knight-native, knight-posix, x86, amd64 and armv7l", stderr);
+				fputs(" know values are: knight-native, knight-posix, x86, amd64, armv7l, riscv32 and riscv64", stderr);
 			}
 			option_index = option_index + 2;
 		}
@@ -652,7 +657,7 @@ int main(int argc, char **argv)
 			fputs(argv[0], stderr);
 			fputs(" --file FILENAME1 {-f FILENAME2} (--big-endian|--little-endian)", stderr);
 			fputs(" [--base-address 0x12345] [--architecture name]\nArchitecture:", stderr);
-			fputs(" knight-native, knight-posix, x86, amd64, armv7l and aarch64\n", stderr);
+			fputs(" knight-native, knight-posix, x86, amd64, armv7l, aarch64, riscv32 and riscv64\n", stderr);
 			fputs("To leverage octal or binary input: --octal, --binary\n", stderr);
 			exit(EXIT_SUCCESS);
 		}
@@ -703,7 +708,7 @@ int main(int argc, char **argv)
 	}
 
 	/* Catch implicitly false assumptions */
-	if(BigEndian && ((X86 == Architecture) || ( AMD64 == Architecture) || (ARMV7L == Architecture) || (AARM64 == Architecture)))
+	if(BigEndian && ((X86 == Architecture) || ( AMD64 == Architecture) || (ARMV7L == Architecture) || (AARM64 == Architecture) || (RISCV32 == Architecture) || (RISCV64 == Architecture)))
 	{
 		fputs(">> WARNING <<\n>> WARNING <<\n>> WARNING <<\n", stderr);
 		fputs("You have specified big endian output on likely a little endian processor\n", stderr);


### PR DESCRIPTION
This adds the minimal support to handle RISC-V in `mescc`, along with the mes patch series posted here: https://lists.gnu.org/archive/html/bug-mes/2021-04/msg00031.html