### PR TITLE
Fix . handling in hex2

### DIFF
--- a/M1-macro.c
+++ b/M1-macro.c
@@ -147,9 +147,9 @@ void NewBlob(int size)
 {
 	blob_count = blob_count + 1;
 	struct blob* a = calloc(1, sizeof(struct blob));
-	require(NULL != a, "Exhusted available memory\n");
+	require(NULL != a, "Exhausted available memory\n");
 	a->Text = calloc(size + 1, sizeof(char));
-	require(NULL != a->Text, "Exhusted available memory\n");
+	require(NULL != a->Text, "Exhausted available memory\n");
 
 	int i = 0;
 	while(i <= size)
@@ -167,7 +167,7 @@ struct Token* newToken(char* filename, int linenumber)
 	struct Token* p;
 
 	p = calloc (1, sizeof (struct Token));
-	require(NULL != p, "Exhusted available memory\n");
+	require(NULL != p, "Exhausted available memory\n");
 
 	p->filename = filename;
 	p->linenumber = linenumber;
@@ -382,7 +382,7 @@ void hexify_string(struct blob* p)
 
 	require(1 != size, "hexify_string lacked a valid bytemode\n");
 	char* d = calloc(size, sizeof(char));
-	require(NULL != d, "Exhusted available memory\n");
+	require(NULL != d, "Exhausted available memory\n");
 	p->Expression = d;
 	char* S = p->Text;
 
@@ -466,7 +466,7 @@ char* pad_nulls(int size, char* nil)
 	else if (BINARY == ByteMode) size = size * 8;
 
 	char* s = calloc(size + 1, sizeof(char));
-	require(NULL != s, "Exhusted available memory\n");
+	require(NULL != s, "Exhausted available memory\n");
 
 	int i = 0;
 	while(i < size)
@@ -616,7 +616,7 @@ int stringify(char* s, int digits, int divisor, int value, int shift)
 char* express_number(int value, char c)
 {
 	char* ch = calloc(42, sizeof(char));
-	require(NULL != ch, "Exhusted available memory\n");
+	require(NULL != ch, "Exhausted available memory\n");
 	int size;
 	int number_of_bytes;
 	int shift;
@@ -684,7 +684,7 @@ char* express_word(int value, char c)
 	char* s = calloc(43, sizeof(char));
 	s[0] = '.';
 	char* ch = s + 1;
-	require(NULL != ch, "Exhusted available memory\n");
+	require(NULL != ch, "Exhausted available memory\n");
 	int size;
 	int shift;
 	int immediate;
@@ -700,7 +700,7 @@ char* express_word(int value, char c)
 	}
 	else if('~' == c)
 	{
-		/*Corresponds with RISC-V U format */
+		/* Corresponds with RISC-V U format */
 		if ((value & 0xfff) < 0x800)
 		{
 			immediate = value & 0xfffff000;

--- a/hex2_word.c
+++ b/hex2_word.c
@@ -62,7 +62,7 @@ void UpdateShiftRegister(char ch, int value)
 		/* Will need architecture specific logic if more architectures go this route */
 		/* no range check because it needs to work with labels for lui/addi + AUIPC combos */
 		/* !label is used in the second instruction of AUIPC combo but we want an offset from */
-		/* the first instruction.  */
+		/* the first instruction */
 		value = value + 4;
 		tempword = (value & 0xfff) << 20;
 		/* Update shift register */
@@ -86,7 +86,6 @@ void UpdateShiftRegister(char ch, int value)
 	{
 		/* Corresponds with RISC-V J format (formerly known as UJ) */
 		/* Will need architecture specific logic if more architectures go this route */
-		/* Possibly incorrect */
 		if ((value < -0x100000 || value > 0xfffff) || (value & 1)) outOfRange("J", value);
 
 		tempword = ((value & 0x7fe) << (30 - 10))
@@ -99,7 +98,6 @@ void UpdateShiftRegister(char ch, int value)
 	{
 		/* Corresponds with RISC-V U format */
 		/* Will need architecture specific logic if more architectures go this route */
-		/* Possibly incorrect */
 		if ((value & 0xfff) < 0x800) tempword = value & 0xfffff000;
 		else tempword = (value & 0xfffff000) + 0x1000;
 		shiftregister = shiftregister ^ tempword;

--- a/hex2_word.c
+++ b/hex2_word.c
@@ -277,8 +277,8 @@ void WordFirstPass(struct input_files* input)
 			{
 				c = fgetc(source_file);
 				DoByte(c, source_file, FALSE, TRUE);
-				ip = ip - 1;
 			}
+			ip = ip - 4;
 		}
 		else if(in_set(c, "!@$~"))
 		{
@@ -345,9 +345,9 @@ void WordSecondPass(struct input_files* input)
 			{
 				c = fgetc(source_file);
 				DoByte(c, source_file, FALSE, TRUE);
-				ip = ip - 1;
 			}
 			UpdateShiftRegister('.', tempword);
+			ip = ip - 4;
 		}
 		else if(in_set(c, "%&")) WordStorePointer(c, source_file);  /* Deal with % and & */
 		else if(in_set(c, "!@$~"))


### PR DESCRIPTION
Instruction pointer has to be subtracted after shift register is calculated.

Also removed "Possibly incorrect" comments. Those seem to work just fine.