### PR TITLE
Add support for negative zero immediate.

### DIFF
--- a/M1-macro.c
+++ b/M1-macro.c
@@ -709,7 +709,7 @@ void eval_immediates(struct blob* p)
 				{
 					value = strtoint(i->Text + 1);
 
-					if(('0' == i->Text[1]) || (0 != value))
+					if(('0' == i->Text[1]) || (0 != value) || (('-' == i->Text[1]) && ('0' == i->Text[2])))
 					{
 						i->Expression = express_word(value, i->Text[0]);
 					}


### PR DESCRIPTION
Alternatively, I can fix M2-Planet not to spit out negative zeroes (this is mainly affecting risc-v)