### PR TITLE
Long name aliases

### DIFF
--- a/Kaem/kaem.c
+++ b/Kaem/kaem.c
@@ -466,6 +466,9 @@ int collect_alias_token(char* input, char* n, int index)
 		}
 	} while(token_done == FALSE);
 
+        /* Terminate the output with a NULL */
+        n[output_index] = 0;
+
 	return index;
 }
 


### PR DESCRIPTION
Handle cases when the alias name is longer than the command.

e.g. `alias touch=catm`