### PR TITLE
Double maximum number of arguments that kaem supports.

### DIFF
--- a/Kaem/kaem.h
+++ b/Kaem/kaem.h
@@ -30,7 +30,7 @@
 // CONSTANT FAILURE 1
 #define FAILURE 1
 #define MAX_STRING 4096
-#define MAX_ARRAY 256
+#define MAX_ARRAY 512
 
 
 /*


### PR DESCRIPTION
As number of C files in meslibc grows, this would help us to build it.