### PR TITLE
Add parallelisation to kaem

### DIFF
--- a/Kaem/kaem.h
+++ b/Kaem/kaem.h
@@ -56,4 +56,15 @@ struct Token
 	struct Token* next;
 };
 
+/*
+ * Pending execution struct - holds commands in parallel mode that have not yet been run.
+ */
+struct ExecUnit
+{
+	char** array;
+	char** envp;
+	char *program;
+	struct ExecUnit* next;
+};
+
 #include "kaem_globals.h"

--- a/Kaem/kaem_globals.c
+++ b/Kaem/kaem_globals.c
@@ -25,6 +25,7 @@ int STRICT;
 int INIT_MODE;
 int FUZZING;
 int WARNINGS;
+int PARALLEL;
 char* KAEM_BINARY;
 char* PATH;
 
@@ -34,3 +35,5 @@ struct Token* token;
 struct Token* env;
 /* Alias linked-list; stores the aliases */
 struct Token* alias;
+
+struct ExecUnit* pending_exec;

--- a/Kaem/kaem_globals.h
+++ b/Kaem/kaem_globals.h
@@ -23,6 +23,7 @@ extern int STRICT;
 extern int INIT_MODE;
 extern int FUZZING;
 extern int WARNINGS;
+extern int PARALLEL;
 extern char* KAEM_BINARY;
 extern char* PATH;
 
@@ -32,3 +33,5 @@ extern struct Token* token;
 extern struct Token* env;
 /* Alias linked-list; stores the aliases */
 extern struct Token* alias;
+
+extern struct ExecUnit* pending_exec;


### PR DESCRIPTION
Enabled by the _begin_parallel and _end_parallel commands. For example,

```
_begin_parallel 4
cc a.c
cc b.c
[...]
_end_parallel
```

will execute up to 4 of the cc commands in parallel at a time.

Note that this is lazy parallelisation; all commands are run at the _end_parallel command, in a non-deterministic order. As such, builtins are not permitted to be run in a _begin_parallel/_end_parallel block.