### PR TITLE
Guard headers against multiple includes

### DIFF
--- a/Kaem/kaem.h
+++ b/Kaem/kaem.h
@@ -16,6 +16,9 @@
  * along with mescc-tools.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _KAEM_H
+#define _KAEM_H
+
 #include <stdio.h>
 #include "../M2libc/bootstrappable.h"
 
@@ -55,3 +58,4 @@ struct Token
 };
 
 #include "kaem_globals.h"
+#endif

--- a/Kaem/kaem_globals.h
+++ b/Kaem/kaem_globals.h
@@ -16,6 +16,9 @@
  * along with mescc-tools.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _KAEM_GLOBALS_H
+#define _KAEM_GLOBALS_H
+
 extern int command_done;
 extern int VERBOSE;
 extern int VERBOSE_EXIT;
@@ -32,3 +35,5 @@ extern struct Token* token;
 extern struct Token* env;
 /* Alias linked-list; stores the aliases */
 extern struct Token* alias;
+
+#endif

--- a/hex2.h
+++ b/hex2.h
@@ -17,6 +17,9 @@
  * along with mescc-tools.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _HEX2_H
+#define _HEX2_H
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -55,3 +58,4 @@ struct entry
 	char* name;
 };
 
+#endif

--- a/hex2_globals.h
+++ b/hex2_globals.h
@@ -17,6 +17,9 @@
  * along with mescc-tools.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _HEX2_GLOBALS_H
+#define _HEX2_GLOBALS_H
+
 #include "hex2.h"
 
 /* Global variables */
@@ -48,3 +51,5 @@ void pad_to_align(int write);
 int hex(int c, FILE* source_file);
 int octal(int c, FILE* source_file);
 int binary(int c, FILE* source_file);
+
+#endif


### PR DESCRIPTION
M2 added optional support for `#include` about 4 months ago, however it didn't detect when it's including the same header multiple times, and would error when attempting to add the duplicate definitions. This should fix that error, and as a bonus, let users performing the bootstrap process to not list every M2libc dependency when compiling kaem and hex2.