### PR TITLE
kaem.h: bump MAX_ARRAY

### DIFF
--- a/Kaem/kaem.h
+++ b/Kaem/kaem.h
@@ -31,7 +31,7 @@
 #define SUCCESS 0
 #define FAILURE 1
 #define MAX_STRING 4096
-#define MAX_ARRAY 512
+#define MAX_ARRAY 4096
 
 
 /*


### PR DESCRIPTION
When creating full musl libc.a, about 1100 objects files need to linked,
and `tcc` cannot create static libraries incrementally, as far as I
know. Therefore, bump `MAX_ARRAY`.

See #56 for further context.

